### PR TITLE
Support Laravel 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This package helps you to generate the breadcrumb component for your app in Laravel
 
 ## Compatibilty
-This package is currently only compatible with [Laravel](http://www.laravel.com) 5.3.*
+This package is currently compatible with [Laravel](http://www.laravel.com) 5.3+
 
 ## Instalation
 ### Using [Composer](http://getcomposer.org/):

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "laravel/framework": "5.4.*"
+        "laravel/framework": "5.3.*||5.4.*||5.5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adds support for Laravel 5.5, while mantaining support for 5.3 & 5.4.

A :gift: from a friend from Styde

:octocat: